### PR TITLE
Add FAST A20 method

### DIFF
--- a/kernel.asm
+++ b/kernel.asm
@@ -1100,7 +1100,7 @@ try_fast_a20:
 	out 0x92, al
 	after:
 	; Test to see if that worked
-	call check_A20
+	call check_a20
 	cmp ax, 0
 	je  a20_failed
 a20_keyb:

--- a/kernel.asm
+++ b/kernel.asm
@@ -1086,9 +1086,23 @@ a20_ns:
 	; Check to make sure it is enabled
 	call check_a20
 	cmp ax, 0
-	je  a20_failed
+	je  try_fast_a20
+a20_success:
 	; Enabled successfully.
 	ret 
+try_fast_a20:
+	; Attempt to use FAST A20 to enable the A20 line.
+	in al, 0x92
+	test al, 2
+	jnz after
+	or al, 2
+	and al, 0xFE
+	out 0x92, al
+	after:
+	; Test to see if that worked
+	call check_A20
+	cmp ax, 0
+	je  a20_failed
 a20_keyb:
 	cli
  

--- a/kernel.asm
+++ b/kernel.asm
@@ -1055,6 +1055,10 @@ halt_forever:
 	jmp halt_forever
 a20_line_ena:
 	; NOTE: Credit for all A20 code goes to the OSDev wiki.
+	; First go ahead and check if the A20 line is already activated
+	call check_a20
+	cmp ax, 1
+	je  a20_activated
 	; Enable the high memory area.
 	mov	ax,2403h		;--- A20-Gate Support ---
 	int	15h
@@ -1103,6 +1107,8 @@ try_fast_a20:
 	call check_a20
 	cmp ax, 0
 	je  a20_failed
+	; If we are here, we have it activated.
+	ret
 a20_keyb:
 	cli
  


### PR DESCRIPTION
This is here to provide a last-ditch effort to enable the A20 line. If
this method does not work then the machine we are tying this on truly does
not support the A20 line.

Signed-off-by: nkeck720 <noahkeck72@gmail.com>